### PR TITLE
Add Fixed Import Path

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+        "baseUrl": "src"
+    },
+    "include": [
+        "src"
+    ],
+    "exclude": [
+        "node_modules",
+        "**/node_modules/*"
+    ]
+}

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import App from './App';
+import App from "App";
 
 test('renders learn react link', () => {
   render(<App />);


### PR DESCRIPTION
# Description
Configuration of the file "jsconfig.js" in order to use fixed import path.

### Example
Before
import Home from './views/pages/home';

Now
import Home from "views/pages/home";
