### PR TITLE
Add Personalized Light Theme

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,16 +1,10 @@
 import logo from './logo.svg';
 import './App.css';
-import { createTheme, ThemeProvider } from '@mui/material/styles';
-import CssBaseline from '@mui/material/CssBaseline';
-
 import VLibras from '@djpfs/react-vlibras'
 
-const defaultTheme = createTheme();
 
 function App() {
   return (
-    <ThemeProvider theme={defaultTheme}>
-      <CssBaseline />
       <div className="App">
         <VLibras />
         <header className="App-header">
@@ -28,8 +22,6 @@ function App() {
           </a>
         </header>
       </div>
-    </ThemeProvider>
-
   );
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,9 @@ import '@fontsource/roboto/700.css';
 import './index.css';
 
 import reportWebVitals from './reportWebVitals';
+import { ThemeProvider } from '@mui/material/styles';
+import CssBaseline from '@mui/material/CssBaseline';
+import dossieIdosoLightTheme from 'views/themes/dossieIdosoLightTheme';
 
 import {
   createBrowserRouter,
@@ -32,7 +35,10 @@ const router = createBrowserRouter([
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <RouterProvider router={router} />  
+    <ThemeProvider theme={dossieIdosoLightTheme}>
+      <CssBaseline />
+      <RouterProvider router={router} />
+    </ThemeProvider>
   </React.StrictMode>
 );
 

--- a/src/views/themes/dossieIdosoLightTheme.js
+++ b/src/views/themes/dossieIdosoLightTheme.js
@@ -1,8 +1,31 @@
-import { createTheme } from '@mui/material/styles';
+import { createTheme } from "@mui/material/styles";
 
 const dossieIdosoLightTheme = createTheme({
-    palette: {
+  palette: {
+    mode: "light",
+    primary: {
+      main: "#6750A4",
+
     },
+    secondary: {
+      main: "#625B71",
+    
+    },
+    tertiary: {
+      main: "#7D5260",
+    },
+    error: {
+      main: "#B3261E",
+    },
+    background: {
+      default: "#ffffff",
+    },
+    typography: {
+        fontFamily: "Roboto, Arial, sans-serif",
+      },
+  },
+
+  
 });
 
 export default dossieIdosoLightTheme;

--- a/src/views/themes/dossieIdosoLightTheme.js
+++ b/src/views/themes/dossieIdosoLightTheme.js
@@ -1,0 +1,8 @@
+import { createTheme } from '@mui/material/styles';
+
+const dossieIdosoLightTheme = createTheme({
+    palette: {
+    },
+});
+
+export default dossieIdosoLightTheme;


### PR DESCRIPTION
# Description

In this PR, the light theme is added to our project.

- The styles for light theme from Figma (https://www.figma.com/design/rKYagFEnpPuNfrHPbOVBFK/Colors-sonkopet?node-id=0-1&t=uqxAuSz2JEgKD4X6-0) was mapped to our project.